### PR TITLE
Dead Sprite fix

### DIFF
--- a/src/player_animations.js
+++ b/src/player_animations.js
@@ -156,6 +156,8 @@ let DeathAnimation = stampit.compose(Animation)
       }
     },
     handleStart: function() {
+      this.subject.setSizeY(1);
+      this.subject.setSpriteSizeY(1);
       this.subject.setSpritePosition(new THREE.Vector2( 6, 0));
       this.deathDelay = 0.5;
       this.subject.animated = false;


### PR DESCRIPTION
The bug with Mario's Dead Sprite is fixed :)
By me!
I made sure that Mario's Sprite size is One before Mario's Die Sprite played.

Fixes #17 